### PR TITLE
useecs - Make -fix safer

### DIFF
--- a/internal/analysis/useecs/useecs_test.go
+++ b/internal/analysis/useecs/useecs_test.go
@@ -43,18 +43,12 @@ func Test(t *testing.T) {
 				},
 			},
 		},
-		{
-			Path:                  "testdata/fields.yml",
-			IgnoreConstantKeyword: true,
-		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 
 		t.Run(filepath.Base(tc.Path), func(t *testing.T) {
-			ignoreConstantKeyword = tc.IgnoreConstantKeyword
-
 			_, diags, err := fydler.Run([]*analysis.Analyzer{Analyzer}, tc.Path)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
There are attributes like `metric_type` or `dimension` that should be retained when adding 'external: ecs'.

Additionally it is safe to use 'external: ecs' on keyword fields that are used as constant_keyword fields.