### PR TITLE
feat(ci): use golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,42 +1,50 @@
----
-
+version: "2"
 run:
-  issues-exit-code: 1
   modules-download-mode: readonly
-
+  issues-exit-code: 1
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - gosimple
+    - errorlint
+    - godox
     - govet
     - ineffassign
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unused
-    - errorlint
-    - gofumpt
-    - goimports
-    - godox
     - misspell
+    - revive
+    - staticcheck
     - unconvert
     - unused
-    - revive
-  fast: false
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/andrewkroh/fydler
-  gofumpt:
-    extra-rules: true
-  stylecheck:
-    checks:
-      - all
-
-issues:
-  include:
-   # If you're going to write a comment follow the conventions.
-   # https://go.dev/doc/effective_go#commentary.
-   # comment on exported (.+) should be of the form "(.+)..."
-   - EXC0014
+  settings:
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+    rules:
+      - path: internal/
+        text: should have comment or be unexported
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/andrewkroh/fydler
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package analysis provides a framework for analyzing and modifying
+// fields.yml files.
 package analysis
 
 import (

--- a/internal/analysis/conflict/conflict.go
+++ b/internal/analysis/conflict/conflict.go
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package conflict provides an analyzer that detects conflicting data types
+// across declarations of fields with the same name. It is used to ensure that
+// fields are not declared with different data types in different data streams.
 package conflict
 
 import (

--- a/internal/analysis/duplicate/duplicate.go
+++ b/internal/analysis/duplicate/duplicate.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package duplicate detects duplicate field declarations within a directory.
 package duplicate
 
 import (

--- a/internal/analysis/dynamicfield/dynamicfield.go
+++ b/internal/analysis/dynamicfield/dynamicfield.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package dynamicfield provides an analyzer for detecting issues with
+// wildcard fields meant to be dynamic mappings.
 package dynamicfield
 
 import (

--- a/internal/analysis/ecsdefinitionfact/ecsdefinitionfact.go
+++ b/internal/analysis/ecsdefinitionfact/ecsdefinitionfact.go
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package ecsdefinitionfact provides a fact that gathers the external ECS
+// definition for fields. It uses the ECS version fact to determine the
+// version of ECS to use for the lookup.
 package ecsdefinitionfact
 
 import (

--- a/internal/analysis/ecsversionfact/ecsversionfact.go
+++ b/internal/analysis/ecsversionfact/ecsversionfact.go
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package ecsversionfact provides a fact that returns the ECS version
+// associated with a fields.yml file. The ECS version is determined
+// by looking for a build.yml file for the package containing the fields.
 package ecsversionfact
 
 import (

--- a/internal/analysis/invalidattribute/invalidattribute.go
+++ b/internal/analysis/invalidattribute/invalidattribute.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package invalidattribute detects invalid usages of field attributes.
 package invalidattribute
 
 import (

--- a/internal/analysis/nesting/nesting.go
+++ b/internal/analysis/nesting/nesting.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package nesting detects fields that are nested below a scalar type field.
 package nesting
 
 import (

--- a/internal/analysis/unknownattribute/unknownattribute.go
+++ b/internal/analysis/unknownattribute/unknownattribute.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package unknownattribute detects unknown field attributes in fields.yml files.
 package unknownattribute
 
 import (

--- a/internal/analysis/useecs/useecs.go
+++ b/internal/analysis/useecs/useecs.go
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package useecs provides an analyzer that detects fields that exist in the
+// latest version of ECS, but are not using 'external: ecs'.
+// It can also fix the issue by replacing the field definition with a new one
+// that uses 'external: ecs'.
 package useecs
 
 import (

--- a/internal/fydler/fydler.go
+++ b/internal/fydler/fydler.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package fydler provides the core functionality for the fydler tool.
+// It provides the logic for running analyzers based on the provided CLI flags.
 package fydler
 
 import (

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package printer provides functions to print diagnostics in different formats.
 package printer
 
 import (

--- a/internal/yamledit/doc.go
+++ b/internal/yamledit/doc.go
@@ -15,30 +15,5 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Package missingtype checks for fields that are declared without a type.
-package missingtype
-
-import (
-	"fmt"
-
-	"github.com/andrewkroh/fydler/internal/analysis"
-)
-
-var Analyzer = &analysis.Analyzer{
-	Name:        "missingtype",
-	Description: "Detect fields declared without a 'type'.",
-	Run:         run,
-}
-
-func run(pass *analysis.Pass) (interface{}, error) {
-	for _, f := range pass.Flat {
-		if f.Type == "" && f.External == "" {
-			pass.Report(analysis.Diagnostic{
-				Pos:      analysis.NewPos(f.FileMetadata),
-				Category: pass.Analyzer.Name,
-				Message:  fmt.Sprintf("%s is missing a 'type'", f.Name),
-			})
-		}
-	}
-	return nil, nil
-}
+// Package yamledit provides functions to edit YAML files.
+package yamledit

--- a/main.go
+++ b/main.go
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// The fydler command examines fields.yml files and reports issues that
+// it detects. It can automatically fix some issues, such as removing
+// duplicate field definitions.
 package main
 
 import (


### PR DESCRIPTION
Migrate the configuration to the v2 format.

Address warnings about missing package-level godocs.