### PR TITLE
fix(analysis): resolve alias types in conflict analyzer

### DIFF
--- a/internal/analysis/aliasfact/aliasfact.go
+++ b/internal/analysis/aliasfact/aliasfact.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package aliasfact provides a fact that resolves the type of alias target
+// fields. It uses the ECS definition fact to ensure that any external ECS
+// definitions are resolved. The fleetpkg.Field.Type is overwritten with the
+// type of the target field. A diagnostic is reported if the target field does
+// not exist in the same directory, and the unresolved alias field is included
+// in the fact.
+package aliasfact
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/andrewkroh/go-fleetpkg"
+
+	"github.com/andrewkroh/fydler/internal/analysis"
+	"github.com/andrewkroh/fydler/internal/analysis/ecsdefinitionfact"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:        "aliasfact",
+	Description: "Gathers the field type of the target field of an alias.",
+	Run:         run,
+	Requires:    []*analysis.Analyzer{ecsdefinitionfact.Analyzer},
+}
+
+type Fact struct {
+	ResolvedAliases []*fleetpkg.Field // Field data where the type is overwritten with the type of the target field.
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	ecsDefinitionFact := pass.ResultOf[ecsdefinitionfact.Analyzer].(*ecsdefinitionfact.Fact)
+	fact := &Fact{ResolvedAliases: make([]*fleetpkg.Field, 0, len(ecsDefinitionFact.EnrichedFlat))}
+
+	for _, f := range ecsDefinitionFact.EnrichedFlat {
+		if f.Type != "alias" {
+			fact.ResolvedAliases = append(fact.ResolvedAliases, f)
+			continue
+		}
+		dir := filepath.Dir(f.Path())
+
+		var resolvedType string
+		for _, aliased := range ecsDefinitionFact.EnrichedFlat {
+			if f.AliasTargetPath == aliased.Name {
+				aliasedDir := filepath.Dir(aliased.Path())
+				if dir != aliasedDir {
+					continue
+				}
+
+				resolvedType = aliased.Type
+				break
+			}
+		}
+
+		if resolvedType == "" {
+			pass.Report(analysis.Diagnostic{
+				Pos:      analysis.NewPos(f.FileMetadata),
+				Category: pass.Analyzer.Name,
+				Message:  fmt.Sprintf("%s is declared as an alias, but the aliased field %s does not exist in the same directory", f.Name, f.AliasTargetPath),
+			})
+
+			// Put the unresolved alias into the list so that it can be considered by downstream analyzers.
+			fact.ResolvedAliases = append(fact.ResolvedAliases, f)
+			continue
+		}
+
+		// Copy-on-write.
+		{
+			tmp := *f
+			f = &tmp
+		}
+		f.Type = resolvedType
+
+		fact.ResolvedAliases = append(fact.ResolvedAliases, f)
+	}
+
+	return fact, nil
+}

--- a/internal/analysis/aliasfact/aliasfact_test.go
+++ b/internal/analysis/aliasfact/aliasfact_test.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package aliasfact
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/andrewkroh/fydler/internal/analysis"
+	"github.com/andrewkroh/fydler/internal/fydler"
+)
+
+func Test(t *testing.T) {
+	testCases := []struct {
+		Path   string
+		Diags  []analysis.Diagnostic
+		Fields map[string]string
+	}{
+		{
+			Path: "testdata/my_package/data_stream/alias/fields/alias.yml",
+			Fields: map[string]string{
+				"body":    "match_only_text",
+				"message": "match_only_text",
+			},
+		},
+		{
+			Path: "testdata/my_package/data_stream/unresolved_alias/fields/unresolved_alias.yml",
+			Fields: map[string]string{
+				"body": "alias",
+			},
+			Diags: []analysis.Diagnostic{
+				{
+					Pos: analysis.Pos{
+						File: "testdata/my_package/data_stream/unresolved_alias/fields/unresolved_alias.yml",
+						Line: 2,
+						Col:  3,
+					},
+					Category: "aliasfact",
+					Message:  "body is declared as an alias, but the aliased field message does not exist in the same directory",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(filepath.Base(tc.Path), func(t *testing.T) {
+			results, diags, err := fydler.Run([]*analysis.Analyzer{Analyzer}, tc.Path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.Diags, diags)
+
+			fact := results[Analyzer].(*Fact)
+			require.Len(t, fact.ResolvedAliases, len(tc.Fields), "unexpected ResolvedAliases length")
+			for _, f := range fact.ResolvedAliases {
+				assert.Equal(t, tc.Fields[f.Name], f.Type)
+			}
+		})
+	}
+}

--- a/internal/analysis/aliasfact/testdata/my_package/_dev/build/build.yml
+++ b/internal/analysis/aliasfact/testdata/my_package/_dev/build/build.yml
@@ -1,0 +1,3 @@
+dependencies:
+  ecs:
+    reference: git@v8.17.0

--- a/internal/analysis/aliasfact/testdata/my_package/data_stream/alias/fields/alias.yml
+++ b/internal/analysis/aliasfact/testdata/my_package/data_stream/alias/fields/alias.yml
@@ -1,0 +1,6 @@
+---
+- name: body
+  type: alias
+  path: message
+- name: message
+  external: ecs

--- a/internal/analysis/aliasfact/testdata/my_package/data_stream/unresolved_alias/fields/unresolved_alias.yml
+++ b/internal/analysis/aliasfact/testdata/my_package/data_stream/unresolved_alias/fields/unresolved_alias.yml
@@ -1,0 +1,4 @@
+---
+- name: body
+  type: alias
+  path: message


### PR DESCRIPTION
The conflict analyzer was not resolving the data type of `alias` fields. This resulted in the analyzer not being able to detect type conflicts when a field was defined as an alias to another field with a different type.

This change introduces a new analyzer, `aliasfact`, that runs before the conflict analyzer. The `aliasfact` analyzer is responsible for resolving the type of alias fields by looking up the type of their target field within the same directory. The conflict analyzer then uses this information to perform more accurate conflict detection.

If an alias's target field cannot be found in the same directory, a diagnostic is reported.

Fixes #50