### PR TITLE
refactor: Replace go-fleetpkg with go-package-spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/andrewkroh/fydler
 go 1.26.0
 
 require (
-	github.com/andrewkroh/go-ecs v0.0.0-20260204044457-2d67483e976a
-	github.com/andrewkroh/go-fleetpkg v0.21.0
+	github.com/andrewkroh/go-ecs v0.0.0-20260219195257-9c8305af118d
+	github.com/andrewkroh/go-package-spec v0.0.0-20260311143825-640eca3620f9
 	github.com/fatih/color v1.18.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b
+	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -17,5 +17,5 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/andrewkroh/go-ecs v0.0.0-20260204044457-2d67483e976a h1:97PBoqqEQzZGvZFwfYm6bLpIgzj55beJXrGq/15F5xo=
-github.com/andrewkroh/go-ecs v0.0.0-20260204044457-2d67483e976a/go.mod h1:MDEnOCgOILh8aBc6rhhUiWPyws1aoNxXw/NY/J5oen8=
-github.com/andrewkroh/go-fleetpkg v0.21.0 h1:1PXkUvJVJkbLcoOnnccdche5Ru5Z+xW0DZJvkn1RIH4=
-github.com/andrewkroh/go-fleetpkg v0.21.0/go.mod h1:FOoPEq03FzRDkmcC6VlpH1leiTLLuec05DWQ3YlIgxM=
+github.com/andrewkroh/go-ecs v0.0.0-20260219195257-9c8305af118d h1:clkLJQu0dND56chdl+dBdKNx3d88S36OrgN2Rk4o3Ro=
+github.com/andrewkroh/go-ecs v0.0.0-20260219195257-9c8305af118d/go.mod h1:pbUM1j+N3QqrRV9PD9QUujTFWGllivUFtAj+jYrsRW4=
+github.com/andrewkroh/go-package-spec v0.0.0-20260311143825-640eca3620f9 h1:xx/PpNkdX7hvihrdBnGoD53nuEWWw9ekUWAw1FLMUxY=
+github.com/andrewkroh/go-package-spec v0.0.0-20260311143825-640eca3620f9/go.mod h1:VYFYfQkXOAe7RIOtSSUNfB6k7bn7An3IKRxfJvTvA8g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -16,11 +16,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b h1:DXr+pvt3nC887026GRP39Ej11UATqWDmWuS99x26cD0=
-golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b/go.mod h1:4QTo5u+SEIbbKW1RacMZq1YEfOBqeXa19JeshGi+zc4=
+golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa h1:Zt3DZoOFFYkKhDT3v7Lm9FDMEV06GpzjG2jrqW+QTE0=
+golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/analysis/aliasfact/aliasfact.go
+++ b/internal/analysis/aliasfact/aliasfact.go
@@ -17,7 +17,7 @@
 
 // Package aliasfact provides a fact that resolves the type of alias target
 // fields. It uses the ECS definition fact to ensure that any external ECS
-// definitions are resolved. The fleetpkg.Field.Type is overwritten with the
+// definitions are resolved. The pkgspec.Field.Type is overwritten with the
 // type of the target field. A diagnostic is reported if the target field does
 // not exist in the same directory, and the unresolved alias field is included
 // in the fact.
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
 	"github.com/andrewkroh/fydler/internal/analysis/ecsdefinitionfact"
@@ -42,29 +42,30 @@ var Analyzer = &analysis.Analyzer{
 }
 
 type Fact struct {
-	ResolvedAliases []*fleetpkg.Field // Field data where the type is overwritten with the type of the target field.
+	ResolvedAliases []*pkgspec.Field // Field data where the type is overwritten with the type of the target field.
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	ecsDefinitionFact := pass.ResultOf[ecsdefinitionfact.Analyzer].(*ecsdefinitionfact.Fact)
-	fact := &Fact{ResolvedAliases: make([]*fleetpkg.Field, 0, len(ecsDefinitionFact.EnrichedFlat))}
+	fact := &Fact{ResolvedAliases: make([]*pkgspec.Field, 0, len(ecsDefinitionFact.EnrichedFlat))}
 
 	for _, f := range ecsDefinitionFact.EnrichedFlat {
 		if f.Type != "alias" {
 			fact.ResolvedAliases = append(fact.ResolvedAliases, f)
 			continue
 		}
-		dir := filepath.Dir(f.Path())
+		dir := filepath.Dir(f.FilePath())
 
-		var resolvedType string
+		var resolvedType pkgspec.FieldType
 		for _, aliased := range ecsDefinitionFact.EnrichedFlat {
-			if f.AliasTargetPath == aliased.Name {
-				aliasedDir := filepath.Dir(aliased.Path())
+			if f.Path == aliased.Name {
+				aliasedDir := filepath.Dir(aliased.FilePath())
 				if dir != aliasedDir {
 					continue
 				}
 
 				resolvedType = aliased.Type
+
 				break
 			}
 		}
@@ -73,7 +74,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			pass.Report(analysis.Diagnostic{
 				Pos:      analysis.NewPos(f.FileMetadata),
 				Category: pass.Analyzer.Name,
-				Message:  fmt.Sprintf("%s is declared as an alias, but the aliased field %s does not exist in the same directory", f.Name, f.AliasTargetPath),
+				Message:  fmt.Sprintf("%s is declared as an alias, but the aliased field %s does not exist in the same directory", f.Name, f.Path),
 			})
 
 			// Put the unresolved alias into the list so that it can be considered by downstream analyzers.

--- a/internal/analysis/aliasfact/aliasfact_test.go
+++ b/internal/analysis/aliasfact/aliasfact_test.go
@@ -74,7 +74,7 @@ func Test(t *testing.T) {
 			fact := results[Analyzer].(*Fact)
 			require.Len(t, fact.ResolvedAliases, len(tc.Fields), "unexpected ResolvedAliases length")
 			for _, f := range fact.ResolvedAliases {
-				assert.Equal(t, tc.Fields[f.Name], f.Type)
+				assert.Equal(t, tc.Fields[f.Name], string(f.Type))
 			}
 		})
 	}

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -25,8 +25,9 @@ import (
 	"flag"
 	"io"
 	"strconv"
+	"strings"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"github.com/goccy/go-yaml"
 	"github.com/goccy/go-yaml/ast"
 
@@ -50,8 +51,8 @@ type Pass struct {
 	Fix bool // Should the analyzer apply fixes to AST?
 
 	// Field information.
-	Fields []*fleetpkg.Field // Fields from every file.
-	Flat   []*fleetpkg.Field // Flat view of all fields sorted by file and line number.
+	Fields []*pkgspec.Field // Fields from every file.
+	Flat   []*pkgspec.Field // Flat view of all fields sorted by file and line number.
 
 	// Map of file paths to the AST of that file. This is available when Fix is true.
 	// Analyzers may add, modify, and delete map attributes, but they should not
@@ -75,9 +76,9 @@ type Pos struct {
 	Col  int
 }
 
-func NewPos(meta fleetpkg.FileMetadata) Pos {
+func NewPos(meta pkgspec.FileMetadata) Pos {
 	return Pos{
-		File: meta.Path(),
+		File: meta.FilePath(),
 		Line: meta.Line(),
 		Col:  meta.Column(),
 	}
@@ -115,7 +116,7 @@ type Printer func(diags []Diagnostic, w io.Writer)
 
 // VisitFields can be used to iterate over non-flat fields. Use this when you
 // need to analyze attributes of non-leaf fields.
-func VisitFields(fields []*fleetpkg.Field, v func(*fleetpkg.Field) error) error {
+func VisitFields(fields []*pkgspec.Field, v func(*pkgspec.Field) error) error {
 	for i := range fields {
 		if err := visitField(fields[i], v); err != nil {
 			return err
@@ -124,12 +125,12 @@ func VisitFields(fields []*fleetpkg.Field, v func(*fleetpkg.Field) error) error 
 	return nil
 }
 
-func visitField(f *fleetpkg.Field, v func(*fleetpkg.Field) error) error {
+func visitField(f *pkgspec.Field, v func(*pkgspec.Field) error) error {
 	if err := v(f); err != nil {
 		return err
 	}
-	for _, child := range f.Fields {
-		if err := visitField(&child, v); err != nil {
+	for i := range f.Fields {
+		if err := visitField(&f.Fields[i], v); err != nil {
 			return err
 		}
 	}
@@ -138,17 +139,17 @@ func visitField(f *fleetpkg.Field, v func(*fleetpkg.Field) error) error {
 
 // DeleteKey deletes the specified key from the AST associated with the given field.
 // If pass.Fix is false, then this is a no-op.
-func DeleteKey(field *fleetpkg.Field, key string, pass *Pass) (modified bool, err error) {
+func DeleteKey(field *pkgspec.Field, key string, pass *Pass) (modified bool, err error) {
 	if !pass.Fix {
 		return false, nil
 	}
 
-	p, err := yaml.PathString(field.YAMLPath + "." + key)
+	p, err := yaml.PathString(YAMLPath(field) + "." + key)
 	if err != nil {
 		return false, err
 	}
 
-	ast := pass.AST[field.Path()]
+	ast := pass.AST[field.FilePath()]
 
 	if err := yamledit.DeleteNode(ast.File, p); err != nil {
 		if !errors.Is(err, yaml.ErrNotFoundNode) {
@@ -159,4 +160,30 @@ func DeleteKey(field *fleetpkg.Field, key string, pass *Pass) (modified bool, er
 
 	ast.Modified = true
 	return true, nil
+}
+
+// YAMLPath converts a pkgspec.Field's JsonPointer (RFC 6901 format like
+// "/0/fields/1") into a goccy/go-yaml path string ("$[0].fields[1]").
+func YAMLPath(f *pkgspec.Field) string {
+	ptr := f.JsonPointer
+	if ptr == "" {
+		return ""
+	}
+	parts := strings.Split(ptr, "/")
+	var b strings.Builder
+	b.WriteByte('$')
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		if _, err := strconv.Atoi(p); err == nil {
+			b.WriteByte('[')
+			b.WriteString(p)
+			b.WriteByte(']')
+		} else {
+			b.WriteByte('.')
+			b.WriteString(p)
+		}
+	}
+	return b.String()
 }

--- a/internal/analysis/conflict/conflict.go
+++ b/internal/analysis/conflict/conflict.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 
 	"github.com/andrewkroh/go-ecs"
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"golang.org/x/exp/maps"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
@@ -69,7 +69,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
-func makeDiag(conflicts []*fleetpkg.Field, dataTypes []string) *analysis.Diagnostic {
+func makeDiag(conflicts []*pkgspec.Field, dataTypes []string) *analysis.Diagnostic {
 	if ignoreTextFamilyConflicts && isTextTypeFamilyConflict(dataTypes...) {
 		return nil
 	}
@@ -90,7 +90,7 @@ func makeDiag(conflicts []*fleetpkg.Field, dataTypes []string) *analysis.Diagnos
 	for _, f := range conflicts {
 		diag.Related = append(diag.Related, analysis.RelatedInformation{
 			Pos:     analysis.NewPos(f.FileMetadata),
-			Message: f.Type,
+			Message: string(f.Type),
 		})
 	}
 	return diag
@@ -105,12 +105,12 @@ func nonExternalConflicts(pass *analysis.Pass) error {
 	slices.SortStableFunc(aliasFact.ResolvedAliases, compareFieldByNameAndType)
 
 	var currentKey string
-	var fields []*fleetpkg.Field
+	var fields []*pkgspec.Field
 	dataTypes := map[string]struct{}{}
 	flush := func() {
 		// Aggregate types.
 		for _, f := range fields {
-			dataTypes[f.Type] = struct{}{}
+			dataTypes[string(f.Type)] = struct{}{}
 		}
 		if len(dataTypes) > 1 {
 			if diag := makeDiag(fields, maps.Keys(dataTypes)); diag != nil {
@@ -170,13 +170,13 @@ func externalECSConflicts(pass *analysis.Pass) error {
 			return err
 		}
 
-		if f.Type == ecsField.DataType {
+		if string(f.Type) == ecsField.DataType {
 			continue
 		}
-		if ignoreTextFamilyConflicts && isTextTypeFamilyConflict(f.Type, ecsField.DataType) {
+		if ignoreTextFamilyConflicts && isTextTypeFamilyConflict(string(f.Type), ecsField.DataType) {
 			continue
 		}
-		if ignoreKeywordFamilyConflicts && isKeywordTypeFamilyConflict(f.Type, ecsField.DataType) {
+		if ignoreKeywordFamilyConflicts && isKeywordTypeFamilyConflict(string(f.Type), ecsField.DataType) {
 			continue
 		}
 		pass.Report(analysis.Diagnostic{
@@ -211,7 +211,7 @@ func isKeywordTypeFamilyConflict(dataTypes ...string) bool {
 	return true
 }
 
-func compareFieldByNameAndType(a, b *fleetpkg.Field) int {
+func compareFieldByNameAndType(a, b *pkgspec.Field) int {
 	if c := cmp.Compare(a.Name, b.Name); c != 0 {
 		return c
 	}

--- a/internal/analysis/duplicate/duplicate.go
+++ b/internal/analysis/duplicate/duplicate.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"golang.org/x/exp/maps"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
@@ -35,7 +35,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (any, error) {
-	seen := map[string][]*fleetpkg.Field{}
+	seen := map[string][]*pkgspec.Field{}
 	var currentDir string
 
 	flush := func() {
@@ -63,7 +63,7 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 	for _, f := range pass.Flat {
 		// When the directory changes flush the duplicates.
-		if dir := filepath.Dir(f.Path()); currentDir != dir {
+		if dir := filepath.Dir(f.FilePath()); currentDir != dir {
 			// Reset
 			flush()
 			maps.Clear(seen)

--- a/internal/analysis/ecsdefinitionfact/ecsdefinitionfact.go
+++ b/internal/analysis/ecsdefinitionfact/ecsdefinitionfact.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/andrewkroh/go-ecs"
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
 	"github.com/andrewkroh/fydler/internal/analysis/ecsversionfact"
@@ -42,14 +42,14 @@ var Analyzer = &analysis.Analyzer{
 }
 
 type Fact struct {
-	EnrichedFlat []*fleetpkg.Field // Field data enriched with external field data (type, description, pattern).
+	EnrichedFlat []*pkgspec.Field // Field data enriched with external field data (type, description, pattern).
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	// Only log a Diagnostic once per directory.
 	unknownECSVersion := map[string]struct{}{}
 	ecsVersionsFact := pass.ResultOf[ecsversionfact.Analyzer].(*ecsversionfact.Fact)
-	fact := &Fact{EnrichedFlat: make([]*fleetpkg.Field, 0, len(pass.Flat))}
+	fact := &Fact{EnrichedFlat: make([]*pkgspec.Field, 0, len(pass.Flat))}
 
 	for _, f := range pass.Flat {
 		if f.External != "ecs" {
@@ -60,9 +60,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		// If the ecsVersion is not found, then the ecs.Lookup() will use data
 		// from the latest ECS version. The ecsversionfact will have logged a
 		// diagnostic about that problem.
-		ecsVersion := ecsVersionsFact.ECSVersion(f.Path())
+		ecsVersion := ecsVersionsFact.ECSVersion(f.FilePath())
 
-		dir := filepath.Dir(f.Path())
+		dir := filepath.Dir(f.FilePath())
 		ecsField, err := ecs.Lookup(f.Name, ecsVersion)
 		if err != nil {
 			switch {
@@ -92,7 +92,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				}
 			default:
 				return nil, fmt.Errorf("failed looking up ECS definition of %q from %s:%d:%d using version %q: %w",
-					f.Name, f.Path(), f.Line(), f.Column(), ecsVersion, err)
+					f.Name, f.FilePath(), f.Line(), f.Column(), ecsVersion, err)
 			}
 
 			continue
@@ -103,7 +103,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			tmp := *f
 			f = &tmp
 		}
-		f.Type = ecsField.DataType
+		f.Type = pkgspec.FieldType(ecsField.DataType)
 		f.Pattern = ecsField.Pattern
 		f.Description = ecsField.Description
 

--- a/internal/analysis/ecsdefinitionfact/ecsdefinitionfact_test.go
+++ b/internal/analysis/ecsdefinitionfact/ecsdefinitionfact_test.go
@@ -59,7 +59,7 @@ func Test(t *testing.T) {
 			fact := results[Analyzer].(*Fact)
 			require.Len(t, fact.EnrichedFlat, len(tc.Fields), "unexpected EnrichedFlat length")
 			for _, f := range fact.EnrichedFlat {
-				assert.Equal(t, tc.Fields[f.Name], f.Type)
+				assert.Equal(t, tc.Fields[f.Name], string(f.Type))
 			}
 		})
 	}

--- a/internal/analysis/ecsversionfact/ecsversionfact.go
+++ b/internal/analysis/ecsversionfact/ecsversionfact.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"gopkg.in/yaml.v3"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
@@ -59,7 +59,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			continue
 		}
 
-		dir := filepath.Dir(f.Path())
+		dir := filepath.Dir(f.FilePath())
 		if _, found := dirToECSVersion[dir]; found {
 			continue
 		}
@@ -105,7 +105,7 @@ func lookupECSReference(dir string) (string, error) {
 	}
 	defer f.Close()
 
-	var manifest fleetpkg.BuildManifest
+	var manifest pkgspec.BuildManifest
 	dec := yaml.NewDecoder(f)
 	if err = dec.Decode(&manifest); err != nil {
 		return "", fmt.Errorf("failed to unmarshal %s: %w", f.Name(), err)

--- a/internal/analysis/fieldgroup/fieldgroup.go
+++ b/internal/analysis/fieldgroup/fieldgroup.go
@@ -23,7 +23,7 @@ package fieldgroup
 import (
 	"fmt"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"github.com/goccy/go-yaml"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
@@ -38,7 +38,7 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	return nil, analysis.VisitFields(pass.Fields, func(f *fleetpkg.Field) error {
+	return nil, analysis.VisitFields(pass.Fields, func(f *pkgspec.Field) error {
 		// Only `type: group` and `type: nested` are allowed to have non-empty 'fields'.
 		switch f.Type {
 		case "group", "nested", "":
@@ -67,10 +67,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 }
 
 // fixGroupType sets 'type: group' on the field.
-func fixGroupType(field *fleetpkg.Field, pass *analysis.Pass) (fixed bool, err error) {
-	ast := pass.AST[field.Path()]
+func fixGroupType(field *pkgspec.Field, pass *analysis.Pass) (fixed bool, err error) {
+	ast := pass.AST[field.FilePath()]
 
-	p, err := yaml.PathString(field.YAMLPath + ".type")
+	p, err := yaml.PathString(analysis.YAMLPath(field) + ".type")
 	if err != nil {
 		return false, err
 	}

--- a/internal/analysis/nesting/nesting.go
+++ b/internal/analysis/nesting/nesting.go
@@ -24,7 +24,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
 	"github.com/andrewkroh/fydler/internal/analysis/ecsdefinitionfact"
@@ -41,7 +41,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	ecsDefinitionFact := pass.ResultOf[ecsdefinitionfact.Analyzer].(*ecsdefinitionfact.Fact)
 
 	// Build map of parent field name to child field.
-	parentChildRelations := map[string][]*fleetpkg.Field{}
+	parentChildRelations := map[string][]*pkgspec.Field{}
 	for _, f := range ecsDefinitionFact.EnrichedFlat {
 		if idx := strings.LastIndexByte(f.Name, '.'); idx != -1 {
 			parentName := f.Name[:idx]
@@ -71,11 +71,11 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	return nil, nil
 }
 
-func makeDiag(parent *fleetpkg.Field, children []*fleetpkg.Field) analysis.Diagnostic {
+func makeDiag(parent *pkgspec.Field, children []*pkgspec.Field) analysis.Diagnostic {
 	diag := analysis.Diagnostic{
 		Pos:      analysis.NewPos(parent.FileMetadata),
 		Category: "nesting",
-		Message:  fmt.Sprintf("%s is defined as a scalar type (%s), but sub-fields were found", parent.Name, parent.Type),
+		Message:  fmt.Sprintf("%s is defined as a scalar type (%s), but sub-fields were found", parent.Name, string(parent.Type)),
 		Related:  make([]analysis.RelatedInformation, 0, len(children)),
 	}
 
@@ -85,14 +85,14 @@ func makeDiag(parent *fleetpkg.Field, children []*fleetpkg.Field) analysis.Diagn
 	for _, f := range children {
 		diag.Related = append(diag.Related, analysis.RelatedInformation{
 			Pos:     analysis.NewPos(f.FileMetadata),
-			Message: f.Name + " is sub-field with type " + f.Type,
+			Message: f.Name + " is sub-field with type " + string(f.Type),
 		})
 	}
 	return diag
 }
 
-func compareFieldByFileMetadata(a, b *fleetpkg.Field) int {
-	if c := cmp.Compare(a.Path(), b.Path()); c != 0 {
+func compareFieldByFileMetadata(a, b *pkgspec.Field) int {
+	if c := cmp.Compare(a.FilePath(), b.FilePath()); c != 0 {
 		return c
 	}
 	if c := cmp.Compare(a.Line(), b.Line()); c != 0 {

--- a/internal/analysis/objectmapping/objectmapping.go
+++ b/internal/analysis/objectmapping/objectmapping.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
 )
@@ -39,7 +39,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// This cannot be implemented using pass.Flat because we need to use
 	// f.Fields to filter invalid usages of 'type: object' on things that
 	// should have been 'type: group'. This avoids several false positives.
-	return nil, analysis.VisitFields(pass.Fields, func(f *fleetpkg.Field) error {
+	return nil, analysis.VisitFields(pass.Fields, func(f *pkgspec.Field) error {
 		if f.Type != "object" {
 			return nil
 		}

--- a/internal/analysis/unknownattribute/unknownattribute.go
+++ b/internal/analysis/unknownattribute/unknownattribute.go
@@ -22,9 +22,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"golang.org/x/exp/maps"
-
-	"github.com/andrewkroh/go-fleetpkg"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
 )
@@ -37,9 +36,9 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
-	return nil, analysis.VisitFields(pass.Fields, func(f *fleetpkg.Field) error {
+	return nil, analysis.VisitFields(pass.Fields, func(f *pkgspec.Field) error {
 		// Determinism
-		attrs := maps.Keys(f.AdditionalAttributes)
+		attrs := maps.Keys(f.Extras)
 		slices.Sort(attrs)
 
 		for _, attrName := range attrs {
@@ -78,7 +77,7 @@ var safeToRemove = map[string]bool{
 // deleteUnknownAttribute removes the attribute if it is an attribute that is
 // known to be unused. It must leave all other attributes in place because they
 // may be typos of valid attributes.
-func deleteUnknownAttribute(field *fleetpkg.Field, attr string, pass *analysis.Pass) (fixed bool, err error) {
+func deleteUnknownAttribute(field *pkgspec.Field, attr string, pass *analysis.Pass) (fixed bool, err error) {
 	if _, safe := safeToRemove[attr]; !safe {
 		return false, nil
 	}

--- a/internal/analysis/useecs/useecs.go
+++ b/internal/analysis/useecs/useecs.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 
 	"github.com/andrewkroh/go-ecs"
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"github.com/goccy/go-yaml"
 	yamlast "github.com/goccy/go-yaml/ast"
 
@@ -65,7 +65,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		message := fmt.Sprintf("%s exists in ECS, but the definition is not using 'external: ecs'.", f.Name)
-		if f.Type != "" && ecsField.DataType != f.Type {
+		if f.Type != "" && ecsField.DataType != string(f.Type) {
 			message += fmt.Sprintf(" The ECS type is %s, but this uses %s", ecsField.DataType, f.Type)
 		}
 
@@ -82,7 +82,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 // fixWithExternalECS replaces the field node with a new definition that uses
 // 'external: ecs'. It will retain certain attributes that override indexing
 // behavior of the field.
-func fixWithExternalECS(field *fleetpkg.Field, ecsField *ecs.Field, pass *analysis.Pass) (fixed bool, err error) {
+func fixWithExternalECS(field *pkgspec.Field, ecsField *ecs.Field, pass *analysis.Pass) (fixed bool, err error) {
 	if !pass.Fix {
 		return false, nil
 	}
@@ -92,31 +92,32 @@ func fixWithExternalECS(field *fleetpkg.Field, ecsField *ecs.Field, pass *analys
 	overrideWithConstantKeyword := ecsField.DataType == "keyword" && field.Type == "constant_keyword"
 
 	// The type must be the same in order to do the replacement safely.
-	if field.Type != ecsField.DataType && !overrideWithConstantKeyword {
+	if string(field.Type) != ecsField.DataType && !overrideWithConstantKeyword {
 		return false, nil
 	}
 
 	// Get the old node.
-	p, err := yaml.PathString(field.YAMLPath)
+	yamlPath := analysis.YAMLPath(field)
+	p, err := yaml.PathString(yamlPath)
 	if err != nil {
 		return false, err
 	}
 
-	ast := pass.AST[field.Path()]
+	ast := pass.AST[field.FilePath()]
 
 	n, err := p.FilterFile(ast.File)
 	if err != nil {
-		return false, fmt.Errorf("failed to get YAML node %q: %w", field.YAMLPath, err)
+		return false, fmt.Errorf("failed to get YAML node %q: %w", yamlPath, err)
 	}
 
 	// This operates on pass.Flat where the field name is not the original
 	// name from the YAML node. We need the original name to modify the YAML.
-	var o fleetpkg.Field
+	var o pkgspec.Field
 	if err = yaml.NodeToValue(n, &o); err != nil {
 		return false, fmt.Errorf("failed to read original node: %w", err)
 	}
 
-	newField := fleetpkg.Field{
+	newField := pkgspec.Field{
 		Name:     o.Name,
 		External: "ecs",
 

--- a/internal/fydler/fydler.go
+++ b/internal/fydler/fydler.go
@@ -33,8 +33,9 @@ import (
 	"text/tabwriter"
 	"unicode"
 
-	"github.com/andrewkroh/go-fleetpkg"
+	"github.com/andrewkroh/go-package-spec/pkgspec"
 	"github.com/goccy/go-yaml/parser"
+	"gopkg.in/yaml.v3"
 
 	"github.com/andrewkroh/fydler/internal/analysis"
 	"github.com/andrewkroh/fydler/internal/printer"
@@ -223,15 +224,16 @@ func Run(analyzers []*analysis.Analyzer, files ...string) (results map[*analysis
 		return nil, nil, err
 	}
 
-	fields, err := fleetpkg.ReadFields(files...)
+	fields, err := readFields(files...)
 	if err != nil {
 		return nil, nil, err
 	}
 	slices.SortFunc(fields, compareFieldByFileMetadata)
 
-	flat, err := fleetpkg.FlattenFields(fields)
-	if err != nil {
-		return nil, nil, err
+	flatFields := pkgspec.FlattenFields(fields, nil)
+	flat := make([]pkgspec.Field, len(flatFields))
+	for i := range flatFields {
+		flat[i] = flatFields[i].Field
 	}
 	slices.SortFunc(flat, compareFieldByFileMetadata)
 
@@ -280,35 +282,73 @@ func Run(analyzers []*analysis.Analyzer, files ...string) (results map[*analysis
 	return results, diags, nil
 }
 
-func loadASTs(fields []fleetpkg.Field) (map[string]*analysis.AST, error) {
+func loadASTs(fields []pkgspec.Field) (map[string]*analysis.AST, error) {
 	m := map[string]*analysis.AST{}
 	for _, field := range fields {
-		if _, found := m[field.Path()]; found {
+		if _, found := m[field.FilePath()]; found {
 			continue
 		}
 
-		f, err := parser.ParseFile(field.Path(), parser.ParseComments)
+		f, err := parser.ParseFile(field.FilePath(), parser.ParseComments)
 		if err != nil {
-			return nil, fmt.Errorf("failed loading AST for %s: %w", field.Path(), err)
+			return nil, fmt.Errorf("failed loading AST for %s: %w", field.FilePath(), err)
 		}
 
-		m[field.Path()] = &analysis.AST{File: f}
+		m[field.FilePath()] = &analysis.AST{File: f}
 	}
 	return m, nil
 }
 
-func compareFieldByFileMetadata(a, b fleetpkg.Field) int {
+func compareFieldByFileMetadata(a, b pkgspec.Field) int {
 	return compareFileMetadata(a.FileMetadata, b.FileMetadata)
 }
 
-func compareFileMetadata(a, b fleetpkg.FileMetadata) int {
-	if c := cmp.Compare(a.Path(), b.Path()); c != 0 {
+func compareFileMetadata(a, b pkgspec.FileMetadata) int {
+	if c := cmp.Compare(a.FilePath(), b.FilePath()); c != 0 {
 		return c
 	}
 	if c := cmp.Compare(a.Line(), b.Line()); c != 0 {
 		return c
 	}
 	return cmp.Compare(a.Column(), b.Column())
+}
+
+// readFields reads all files matching the given globs and returns all fields.
+func readFields(globs ...string) ([]pkgspec.Field, error) {
+	var matches []string
+	for _, glob := range globs {
+		m, err := filepath.Glob(glob)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, m...)
+	}
+
+	var fields []pkgspec.Field
+	for _, file := range matches {
+		ff, err := readFieldsFile(file)
+		if err != nil {
+			return nil, err
+		}
+		fields = append(fields, ff...)
+	}
+	return fields, nil
+}
+
+func readFieldsFile(path string) ([]pkgspec.Field, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var fields []pkgspec.Field
+	if err = yaml.Unmarshal(data, &fields); err != nil {
+		return nil, fmt.Errorf("failed reading from %q: %w", path, err)
+	}
+
+	pkgspec.AnnotateFileMetadata(path, &fields)
+	pkgspec.AnnotateFieldPointers(fields)
+	return fields, nil
 }
 
 func compareAnalyzer(a, b *analysis.Analyzer) int {


### PR DESCRIPTION
Replace the go-fleetpkg dependency with andrewkroh/go-package-spec/pkgspec which provides the canonical data types for Elastic Fleet packages.

Key changes:
- FileMetadata.Path() → FileMetadata.FilePath()
- Field.AliasTargetPath → Field.Path
- Field.AdditionalAttributes → Field.Extras
- Field.YAMLPath → Field.JsonPointer (with converter for goccy/go-yaml paths)
- fleetpkg.ReadFields() replaced by local readFields() using pkgspec types
- fleetpkg.FlattenFields() replaced by pkgspec.FlattenFields()
- String type comparisons updated for named string types (FieldType, etc.)